### PR TITLE
Use `cargoLock.lockFile` to version gcdemu - reworked

### DIFF
--- a/templates/chisel/nix/gcd/dpi-lib.nix
+++ b/templates/chisel/nix/gcd/dpi-lib.nix
@@ -14,7 +14,9 @@
 rustPlatform.buildRustPackage rec {
   name = "dpi-lib";
   src = ./../../${dpiLibName};
-  cargoHash = "sha256-DzedUaBSNOT552x+/4RjeUcKs68HxAiejQ60BgZnUYc=";
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+  };
   buildFeatures = lib.optionals sv2023 [ "sv2023" ]
     ++ lib.optionals vpi [ "vpi" ] ++ lib.optionals enable-trace [ "trace" ];
 


### PR DESCRIPTION
As per [Nix manual](https://nixos.org/manual/nixpkgs/unstable/#importing-a-cargo.lock-file), using `cargoLock.lockFile` to version project lockfile can avoid manual regeneration of `cargoHash`, thus improving efficiency when lockfiles are frequently upgraded. This PR implements the described switch.

Though these changes have no immediate effects on this template, it can introduce and recommend this feature to future users, streamlining their development experience.

This is another attempt of #87 with correct history and base.